### PR TITLE
feat: render images as pixelated

### DIFF
--- a/utils/themify.js
+++ b/utils/themify.js
@@ -53,7 +53,7 @@ function getCountImage({ count, theme='moebooru', length=7 }) {
   }, '')
 
   return `<?xml version="1.0" encoding="UTF-8"?>
-<svg width="${x}" height="${y}" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="${x}" height="${y}" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="image-rendering: pixelated;">
     <title>Moe Count</title>
     <g>
       ${parts}


### PR DESCRIPTION
This removes the smoothing filter and makes sure the pixels stay the same no matter how much you zoom in.