### PR TITLE
modify /get/@:name route to verify existance of name

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,10 @@
 node_modules
+*.md
+LICENSE
+.env.example
+.idea
+.vscode
+.DS_Store
+.github
+docker-compose.yml
+extras

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ count.db
 .env.production.local
 
 npm-debug.log*
+
+.idea
+.vscode

--- a/db/sqlite.js
+++ b/db/sqlite.js
@@ -15,6 +15,11 @@ db.exec(`CREATE TABLE IF NOT EXISTS tb_count (
                        DEFAULT (0) 
 );`)
 
+/**
+ *
+ * @param name
+ * @returns {Promise<{name: *, num: number}>}
+ */
 function getNum(name) {
   return new Promise((resolve, reject) => {
     const stmt = db.prepare('SELECT `name`, `num` from tb_count WHERE `name` = ?')

--- a/db/sqlite.js
+++ b/db/sqlite.js
@@ -23,7 +23,7 @@ function getNum(name) {
   })
 }
 
-function getAll(name) {
+function getAll() {
   return new Promise((resolve, reject) => {
     const stmt = db.prepare('SELECT * from tb_count')
     const rows = stmt.all()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,8 @@ services:
     build: .
     ports:
       - "3000:3000"
+    healthcheck:
+      test: wget -nv -t1 --spider 'http://localhost:3000/heart-beat'
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/extras/grafana.json
+++ b/extras/grafana.json
@@ -1,0 +1,422 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 57,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "counter{name=~\"$counters\"}",
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 17,
+        "x": 0,
+        "y": 9
+      },
+      "id": 2,
+      "interval": "30s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(counter{name=~\"$counters\"}[1m])) by (name)",
+          "instant": true,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Counters variations over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom.viz",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Metric"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 240
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 103
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 7,
+        "x": 17,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "counter",
+          "instant": true,
+          "legendFormat": "{{name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 counters",
+      "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Value"
+              }
+            ]
+          }
+        },
+        {
+          "id": "limit",
+          "options": {
+            "limitField": "10"
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "Prometheus",
+          "value": ""
+        },
+        "hide": 2,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(counter,name)",
+        "includeAll": true,
+        "multi": true,
+        "name": "counters",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(counter,name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "moe-counter",
+  "uid": "moe-counter",
+  "version": 3
+}

--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@
 require('dotenv').config();
 const express = require("express");
 const compression = require("compression");
-const { z } = require("zod");
+const {z} = require("zod");
 
 const db = require("./db");
-const { themeList, getCountImage } = require("./utils/themify");
-const { cors, ZodValid } = require("./utils/middleware");
-const { randomArray, logger } = require("./utils");
+const {themeList, getCountImage} = require("./utils/themify");
+const {cors, ZodValid} = require("./utils/middleware");
+const {randomArray, logger} = require("./utils");
 
 const app = express();
 
@@ -18,81 +18,96 @@ app.use(cors());
 app.set("view engine", "pug");
 
 app.get('/', (req, res) => {
-  const site = process.env.APP_SITE || `${req.protocol}://${req.get('host')}`
-  const ga_id = process.env.GA_ID || null
-  res.render('index', {
-    site,
-    ga_id,
-    themeList,
-  })
+    const site = process.env.APP_SITE || `${req.protocol}://${req.get('host')}`
+    const ga_id = process.env.GA_ID || null
+    res.render('index', {
+        site,
+        ga_id,
+        themeList,
+    })
 });
 
 // get the image
 app.get(["/@:name", "/get/@:name"],
-  ZodValid({
-    params: z.object({
-      name: z.string().max(32),
+    ZodValid({
+        params: z.object({
+            name: z.string().max(32),
+        }),
+        query: z.object({
+            theme: z.string().default("moebooru"),
+            padding: z.coerce.number().int().min(0).max(16).default(7),
+            offset: z.coerce.number().min(-500).max(500).default(0),
+            align: z.enum(["top", "center", "bottom"]).default("top"),
+            scale: z.coerce.number().min(0.1).max(2).default(1),
+            pixelated: z.enum(["0", "1"]).default("1"),
+            darkmode: z.enum(["0", "1", "auto"]).default("auto"),
+
+            // Unusual Options
+            num: z.coerce.number().int().min(0).max(1e15).default(0), // a carry-safe integer, less than `2^53-1`, and aesthetically pleasing in decimal.
+            prefix: z.coerce.number().int().min(-1).max(999999).default(-1)
+        })
     }),
-    query: z.object({
-      theme: z.string().default("moebooru"),
-      padding: z.coerce.number().int().min(0).max(16).default(7),
-      offset: z.coerce.number().min(-500).max(500).default(0),
-      align: z.enum(["top", "center", "bottom"]).default("top"),
-      scale: z.coerce.number().min(0.1).max(2).default(1),
-      pixelated: z.enum(["0", "1"]).default("1"),
-      darkmode: z.enum(["0", "1", "auto"]).default("auto"),
+    async (req, res) => {
+        const {name} = req.params;
+        let {theme = "moebooru", num = 0, ...rest} = req.query;
 
-      // Unusual Options
-      num: z.coerce.number().int().min(0).max(1e15).default(0), // a carry-safe integer, less than `2^53-1`, and aesthetically pleasing in decimal.
-      prefix: z.coerce.number().int().min(-1).max(999999).default(-1)
-    })
-  }),
-  async (req, res) => {
-    const { name } = req.params;
-    let { theme = "moebooru", num = 0, ...rest } = req.query;
+        // This helps with GitHub's image cache
+        res.set({
+            "cache-control": "max-age=0, no-cache, no-store, must-revalidate",
+        })
 
-    // This helps with GitHub's image cache
-    res.set({
-      "content-type": "image/svg+xml",
-      "cache-control": "max-age=0, no-cache, no-store, must-revalidate",
-    });
+        // If the path is /get/ and the name does not exist, return 404
+        if (req.path.startsWith("/get/@") && !await ifExistName(String(name))) {
+            res.status(404).send('<p>Not Found</p>');
 
-    const data = await getCountByName(String(name), Number(num));
+            logger.warn(
+                name,
+                'Not Found'
+            )
 
-    if (name === "demo") {
-      res.set("cache-control", "max-age=31536000");
+            return;
+        }
+
+        res.set({
+            "content-type": "image/svg+xml",
+        });
+
+        const data = await getCountByName(String(name), Number(num));
+
+        if (name === "demo") {
+            res.set("cache-control", "max-age=31536000");
+        }
+
+        if (theme === "random") {
+            theme = randomArray(Object.keys(themeList));
+        }
+
+        // Send the generated SVG as the result
+        const renderSvg = getCountImage({
+            count: data.num,
+            theme,
+            ...rest
+        });
+
+        res.send(renderSvg);
+
+        logger.debug(
+            data,
+            {theme, ...req.query},
+            `ip: ${req.headers['x-forwarded-for'] || req.connection.remoteAddress}`,
+            `ref: ${req.get("Referrer") || null}`,
+            `ua: ${req.get("User-Agent") || null}`
+        );
     }
-
-    if (theme === "random") {
-      theme = randomArray(Object.keys(themeList));
-    }
-
-    // Send the generated SVG as the result
-    const renderSvg = getCountImage({
-      count: data.num,
-      theme,
-      ...rest
-    });
-
-    res.send(renderSvg);
-
-    logger.debug(
-      data,
-      { theme, ...req.query },
-      `ip: ${req.headers['x-forwarded-for'] || req.connection.remoteAddress}`,
-      `ref: ${req.get("Referrer") || null}`,
-      `ua: ${req.get("User-Agent") || null}`
-    );
-  }
 );
 
 // JSON record
 app.get("/record/@:name", async (req, res) => {
-  const { name } = req.params;
+    const {name} = req.params;
 
-  const data = await getCountByName(name);
+    const data = await getCountByName(name);
 
-  res.json(data);
+    res.json(data);
 });
 
 app.get("/metrics", async (req, res) => {
@@ -112,13 +127,13 @@ app.get("/metrics", async (req, res) => {
 });
 
 app.get("/heart-beat", (req, res) => {
-  res.set("cache-control", "max-age=0, no-cache, no-store, must-revalidate");
-  res.send("alive");
-  logger.debug("heart-beat");
+    res.set("cache-control", "max-age=0, no-cache, no-store, must-revalidate");
+    res.send("alive");
+    logger.debug("heart-beat");
 });
 
 const listener = app.listen(process.env.APP_PORT || 3000, () => {
-  logger.info("Your app is listening on port " + listener.address().port);
+    logger.info("Your app is listening on port " + listener.address().port);
 });
 
 let __cache_counter = {};
@@ -126,53 +141,72 @@ let enablePushDelay = process.env.DB_INTERVAL > 0
 let needPush = false;
 
 if (enablePushDelay) {
-  setInterval(() => {
-    needPush = true;
-  }, 1000 * process.env.DB_INTERVAL);
+    setInterval(() => {
+        needPush = true;
+    }, 1000 * process.env.DB_INTERVAL);
 }
 
 async function pushDB() {
-  if (Object.keys(__cache_counter).length === 0) return;
-  if (enablePushDelay && !needPush) return;
+    if (Object.keys(__cache_counter).length === 0) return;
+    if (enablePushDelay && !needPush) return;
 
-  try {
-    needPush = false;
-    logger.info("pushDB", __cache_counter);
+    try {
+        needPush = false;
+        logger.info("pushDB", __cache_counter);
 
-    const counters = Object.keys(__cache_counter).map((key) => {
-      return {
-        name: key,
-        num: __cache_counter[key],
-      };
-    });
+        const counters = Object.keys(__cache_counter).map((key) => {
+            return {
+                name: key,
+                num: __cache_counter[key],
+            };
+        });
 
-    await db.setNumMulti(counters);
-    __cache_counter = {};
-  } catch (error) {
-    logger.error("pushDB is error: ", error);
-  }
+        await db.setNumMulti(counters);
+        __cache_counter = {};
+    } catch (error) {
+        logger.error("pushDB is error: ", error);
+    }
 }
 
-async function getCountByName(name, num) {
-  const defaultCount = { name, num: 0 };
+/**
+ * Get the count by name and increase it by 1
+ * @param {string} name
+ * @param {number} num
+ * @param increment
+ * @returns {Promise<{name: *, num: number}|{name: *, num: string}|{name: *, num: *}|{name: *, num: *}>}
+ */
+async function getCountByName(name, num, increment = true) {
+    const defaultCount = {name, num: 0};
 
-  if (name === "demo") return { name, num: "0123456789" };
+    if (name === "demo") return {name, num: "0123456789"};
 
-  if (num > 0) { return { name, num } };
-
-  try {
-    if (!(name in __cache_counter)) {
-      const counter = (await db.getNum(name)) || defaultCount;
-      __cache_counter[name] = counter.num + 1;
-    } else {
-      __cache_counter[name]++;
+    if (num > 0) {
+        return {name, num};
     }
 
-    pushDB();
+    try {
+        if (!(name in __cache_counter)) {
+            const counter = (await db.getNum(name)) || defaultCount;
+            __cache_counter[name] = counter.num + 1;
+        } else {
+            __cache_counter[name]++;
+        }
 
-    return { name, num: __cache_counter[name] };
-  } catch (error) {
-    logger.error("get count by name is error: ", error);
-    return defaultCount;
-  }
+        pushDB();
+
+        return {name, num: __cache_counter[name]};
+    } catch (error) {
+        logger.error("get count by name is error: ", error);
+        return defaultCount;
+    }
+}
+
+async function ifExistName(name) {
+    try {
+        const counter = await db.getNum(name);
+        return !!counter.num;
+    } catch (error) {
+        logger.error("ifExitName is error: ", error);
+        return false;
+    }
 }

--- a/index.js
+++ b/index.js
@@ -95,6 +95,22 @@ app.get("/record/@:name", async (req, res) => {
   res.json(data);
 });
 
+app.get("/metrics", async (req, res) => {
+    try {
+        const allKeys = await db.getAll();
+        let metrics = '';
+        allKeys.forEach(item => {
+            metrics += `counter{name="${item.name}"} ${item.num}\n`;
+        });
+        res.set('Content-Type', 'text/plain');
+        res.send(metrics);
+
+    } catch (error) {
+        logger.error("metrics is error: ", error);
+        res.status(500).send('Internal Server Error');
+    }
+});
+
 app.get("/heart-beat", (req, res) => {
   res.set("cache-control", "max-age=0, no-cache, no-store, must-revalidate");
   res.send("alive");

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ app.get(["/@:name", "/get/@:name"],
 
         // If the path is /get/ and the name does not exist, return 404
         if (req.path.startsWith("/get/@") && !await ifExistName(String(name))) {
-            res.status(404).send('<p>Not Found</p>');
+            res.status(404).send('Not Found');
 
             logger.warn(
                 name,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "zod": "^3.25.61"
   },
   "engines": {
-    "node": "22.13.1"
+    "node": "18"
   },
   "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+dangerouslyAllowAllBuilds: true


### PR DESCRIPTION
Added a condition to check for the existence of the name in the route.

The SVG counter is only returned if the name exists.

No changes for the /@:name or /record routes.

Added this condition to define an instance as semi-public (all endpoints are private, except for the /get/@**** routes) and prevent the creation of a new counter.