### PR TITLE
fix: broken dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18-alpine
 
-RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+RUN corepack enable && corepack prepare pnpm@10 --activate
 
 COPY . /app
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "zod": "^3.25.61"
   },
   "engines": {
-    "node": "22.13.1"
-  },
-  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
+    "node": ">=22",
+    "pnpm": ">=10"
+  }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - better-sqlite3


### PR DESCRIPTION
Fixes #87 

Appears to be caused by https://github.com/journey-ad/moe-counter/commit/abb154a352081538200f7c13d4f888a3b794c093

better-sqlite3 is on an outdated version, afaik node v18 is the last major version with prebuilt bindings

<img width="804" height="555" alt="1761602798_pPwC9cjbNi" src="https://github.com/user-attachments/assets/951b49f1-6199-4a57-a32c-83e43ab359ec" />
